### PR TITLE
[WIP] refactor(category-service): rewrite category service as a microservice

### DIFF
--- a/apps/category-service/src/category-service.controller.ts
+++ b/apps/category-service/src/category-service.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { CategoryService } from './category-service.service';
+
+@Controller()
+export class CategoryServiceController {
+  constructor(private readonly categoryService: CategoryService) {}
+
+  @Get()
+  getHello(): string {
+    return this.categoryService.getHello();
+  }
+}

--- a/apps/category-service/src/category-service.module.ts
+++ b/apps/category-service/src/category-service.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from '~/libs/auth/src';
+import { DatabaseModule } from '~/libs/database/src';
+import { CategoryServiceController } from './category-service.controller';
+import { CategoryService } from './category-service.service';
+
+@Module({
+  imports: [DatabaseModule, AuthModule],
+  controllers: [CategoryServiceController],
+  providers: [CategoryService],
+})
+export class CategoryServiceModule {}

--- a/apps/category-service/src/category-service.service.ts
+++ b/apps/category-service/src/category-service.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class CategoryService {
+  getHello(): string {
+    return 'Hello World!';
+  }
+}

--- a/apps/category-service/src/category-service.service.ts
+++ b/apps/category-service/src/category-service.service.ts
@@ -1,8 +1,24 @@
 import { Injectable } from '@nestjs/common';
+import { ReturnModelType } from '@typegoose/typegoose';
+import { InjectModel } from '~/libs/database/src/model.transformer';
+import { CategoryModel } from './category.model';
 
 @Injectable()
 export class CategoryService {
-  getHello(): string {
-    return 'Hello World!';
+  constructor(
+    @InjectModel(CategoryModel)
+    private readonly categoryModel: ReturnModelType<typeof CategoryModel>,
+  ) {}
+
+  get model() {
+    return this.categoryModel;
+  }
+
+  /**
+   * 通过 categoryID 获取分类
+   * @param id 分类 ID
+   */
+  async findCategoryById(id: string) {
+    return this.categoryModel.findById(id).lean();
   }
 }

--- a/apps/category-service/src/category.dto.ts
+++ b/apps/category-service/src/category.dto.ts
@@ -1,0 +1,80 @@
+/*
+ * @FilePath: /nx-core/apps/category-service/src/category.dto.ts
+ * @author: Wibus
+ * @Date: 2022-09-17 18:18:04
+ * @LastEditors: Wibus
+ * @LastEditTime: 2022-09-17 18:24:28
+ * Coding With IU
+ */
+
+import { UnprocessableEntityException } from '@nestjs/common';
+import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsString, IsOptional, IsBoolean, IsMongoId } from 'class-validator';
+import { uniq } from 'lodash';
+import { IsBooleanOrString } from '~/shared/utils';
+import { CategoryType } from './category.model';
+
+/**
+ * SlugorIdDto 用于根据 slug 或 id 查询
+ */
+export class SlugorIdDto {
+  // slug or id
+  @IsString()
+  @IsOptional()
+  @ApiProperty()
+  query?: string;
+}
+
+export class MultiQueryTagAndCategoryDto {
+  // 查询多个标签和多个分类
+  @IsOptional()
+  @IsBooleanOrString()
+  @Transform(({ value: val }) => {
+    if (val === 'true' || val === '1') {
+      return true;
+    } else {
+      return val;
+    }
+  })
+  tag?: boolean | string;
+}
+
+/**
+ * 获取多个分类
+ */
+export class MultiCategoriesQueryDto {
+  @IsOptional()
+  @IsMongoId({
+    each: true,
+    message: '多分类查询使用逗号分隔, 应为 mongoID',
+  })
+  @Transform(({ value: v }) => uniq(v.split(',')))
+  @ApiProperty({ description: '分类id' })
+  ids?: Array<string>;
+
+  @IsOptional()
+  @IsBoolean()
+  @Transform((b) => Boolean(b))
+  @ApiProperty({ enum: [1, 0], description: '是否查询分类下的文章' })
+  joint?: boolean;
+
+  @IsOptional()
+  @Transform(({ value: v }: { value: string }) => {
+    if (typeof v !== 'string') {
+      throw new UnprocessableEntityException('type must be a string');
+    }
+    switch (v.toLowerCase()) {
+      case 'category':
+        return CategoryType.Category;
+      case 'tag':
+        return CategoryType.Tag;
+      default:
+        return Object.values(CategoryType).includes(+v)
+          ? +v
+          : CategoryType.Category;
+    }
+  })
+  @ApiProperty({ enum: CategoryType, description: '分类类型' })
+  type: CategoryType;
+}

--- a/apps/category-service/src/category.model.ts
+++ b/apps/category-service/src/category.model.ts
@@ -1,0 +1,62 @@
+/*
+ * @FilePath: /nx-core/apps/category-service/src/category.model.ts
+ * @author: Wibus
+ * @Date: 2022-09-17 18:04:22
+ * @LastEditors: Wibus
+ * @LastEditTime: 2022-09-17 18:11:42
+ * Coding With IU
+ */
+
+import { ApiProperty, PartialType } from '@nestjs/swagger';
+import { modelOptions, DocumentType, prop, index } from '@typegoose/typegoose';
+import { IsString, IsNotEmpty, IsEnum, IsOptional } from 'class-validator';
+import { BaseModel } from '~/shared/model/base.model';
+
+export type CategoryDocument = DocumentType<CategoryModel>;
+
+export enum CategoryType {
+  Category,
+  Tag,
+}
+
+@index({ slug: -1 })
+@modelOptions({ options: { customName: 'Category' } })
+export class CategoryModel extends BaseModel {
+  @prop({
+    trim: true, // 去除空格
+    unique: true, // 唯一
+    required: true, // 必填
+  })
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({ description: '分类名' })
+  name!: string;
+
+  @prop({
+    default: CategoryType.Category, // 默认为分类
+  })
+  @IsEnum(CategoryType)
+  @IsOptional()
+  @ApiProperty({ description: '分类类型' })
+  type?: CategoryType;
+
+  @prop({ unique: true, required: true })
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({ description: '分类路径' })
+  slug!: string;
+
+  @prop()
+  @IsString()
+  @IsOptional()
+  @ApiProperty({ description: '分类图标' })
+  icon?: string;
+
+  @IsOptional()
+  @IsString()
+  @ApiProperty({ description: '分类描述' })
+  description?: string;
+}
+
+// 定义一个 Partial 类型 来包含所有的属性
+export class PartialCategoryModel extends PartialType(CategoryModel) {}

--- a/apps/category-service/src/main.ts
+++ b/apps/category-service/src/main.ts
@@ -1,0 +1,18 @@
+import { NestFactory } from '@nestjs/core';
+import { MicroserviceOptions, Transport } from '@nestjs/microservices';
+import { registerStdLogger } from '~/apps/core/src/global/consola.global';
+import { registerGlobal } from '~/apps/core/src/global/index.global';
+import { CategoryServiceModule } from './category-service.module';
+
+async function bootstrap() {
+  registerGlobal();
+  registerStdLogger();
+  const app = await NestFactory.createMicroservice<MicroserviceOptions>(
+    CategoryServiceModule,
+    {
+      transport: Transport.TCP,
+    },
+  );
+  await app.listen();
+}
+bootstrap();

--- a/apps/category-service/tsconfig.app.json
+++ b/apps/category-service/tsconfig.app.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "outDir": "../../dist/apps/category-service"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
+}

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -83,6 +83,15 @@
       "compilerOptions": {
         "tsConfigPath": "libs/config/tsconfig.lib.json"
       }
+    },
+    "category-service": {
+      "type": "application",
+      "root": "apps/category-service",
+      "entryFile": "main",
+      "sourceRoot": "apps/category-service/src",
+      "compilerOptions": {
+        "tsConfigPath": "apps/category-service/tsconfig.app.json"
+      }
     }
   }
 }

--- a/shared/constants/event.constant.ts
+++ b/shared/constants/event.constant.ts
@@ -3,7 +3,7 @@
  * @author: Wibus
  * @Date: 2022-09-03 22:18:46
  * @LastEditors: Wibus
- * @LastEditTime: 2022-09-10 23:51:52
+ * @LastEditTime: 2022-09-17 14:21:00
  * Coding With IU
  */
 
@@ -17,4 +17,13 @@ export enum UserEvents {
   UserCheck = 'user.check',
   UserGet = 'user.get',
   UserGetAllSession = 'user.get.session.all',
+}
+
+export enum CategoryEvents {
+  CategoryCreated = 'category.created',
+  CategoryGet = 'category.get',
+  CategoryGetAll = 'category.get.all',
+  CategoryMerge = 'category.merge',
+  CategoryPatch = 'category.patch',
+  CategoryDelete = 'category.delete',
 }

--- a/shared/constants/services.constant.ts
+++ b/shared/constants/services.constant.ts
@@ -3,19 +3,20 @@
  * @author: Wibus
  * @Date: 2022-09-03 22:28:40
  * @LastEditors: Wibus
- * @LastEditTime: 2022-09-03 22:44:55
+ * @LastEditTime: 2022-09-17 14:19:31
  * Coding With IU
  */
 
 export enum ServicesEnum {
-  user = "USER_SERVICE",
-  auth = "AUTH_SERVICE",
-  backup = "BACKUP_SERVICE",
-  pages = "PAGES_SERVICE",
-  links = "LINKS_SERVICE",
-  comments = "COMMENTS_SERVICE",
-  config = "CONFIG_SERVICE",
-  theme = "THEME_SERVICE",
-  admin = "ADMIN_SERVICE",
-  mail = "MAIL_SERVICE"
+  user = 'USER_SERVICE',
+  auth = 'AUTH_SERVICE',
+  backup = 'BACKUP_SERVICE',
+  category = 'CATEGORY_SERVICE',
+  pages = 'PAGES_SERVICE',
+  links = 'LINKS_SERVICE',
+  comments = 'COMMENTS_SERVICE',
+  config = 'CONFIG_SERVICE',
+  theme = 'THEME_SERVICE',
+  admin = 'ADMIN_SERVICE',
+  mail = 'MAIL_SERVICE',
 }


### PR DESCRIPTION
```bash
# start app in watching mode
nest start -w category-service
```

## 此 PR 修改了什么

重写分类模块，包含标签

## 此 PR 完成进度

- [X] 初始化模块
- [X] 重新定义模型
- [ ] 服务重建
- [ ] 分类双向合并支持

## 此 PR 需要注意的事情

- 此服务启动时全部监听活动事件命名都在 `shared/constants/event.constant.ts` 中
- 分类 model 新增了两个字段：`icon`, `description` 皆为可选