### PR TITLE
feat(user-service): get master info directly

### DIFF
--- a/apps/core/src/modules/user/user.controller.ts
+++ b/apps/core/src/modules/user/user.controller.ts
@@ -3,7 +3,7 @@
  * @author: Wibus
  * @Date: 2022-09-03 22:26:41
  * @LastEditors: Wibus
- * @LastEditTime: 2022-09-25 15:14:48
+ * @LastEditTime: 2022-10-01 15:12:42
  * Coding With IU
  */
 
@@ -73,6 +73,23 @@ export class UserController {
         }),
       );
     return data;
+  }
+
+  @Get('/master/info')
+  @ApiOperation({ summary: '获取主人信息' })
+  async getMaster() {
+    return this.user.send({ cmd: UserEvents.UserGetMaster }, null).pipe(
+      timeout(1000),
+      catchError((err) => {
+        return throwError(
+          () =>
+            new HttpException(
+              err.message || '未知错误，请联系管理员',
+              err.status || 500,
+            ),
+        );
+      }),
+    );
   }
 
   @Post('/register')

--- a/apps/user-service/src/user-service.controller.ts
+++ b/apps/user-service/src/user-service.controller.ts
@@ -15,6 +15,11 @@ export class UserServiceController {
     return this.userService.getUserByUsername(data.username, data.getLoginIp);
   }
 
+  @MessagePattern({ cmd: UserEvents.UserGetMaster })
+  handleUserGetMaster() {
+    return this.userService.getMaster();
+  }
+
   // @EventPattern(UserEvents.UserCheck)
   // handleUserCheckLogged() {}
 

--- a/apps/user-service/src/user-service.service.ts
+++ b/apps/user-service/src/user-service.service.ts
@@ -214,5 +214,14 @@ export class UserService {
     return PrevFootstep as any;
   }
 
-  async getMaster() {}
+  async getMaster() {
+    const master = await this.userModel.findOne({ role: UserRole.root });
+    if (!master) {
+      throw new RpcException({
+        status: HttpStatus.NOT_FOUND,
+        message: ExceptionMessage.UserNotFound,
+      });
+    }
+    return master;
+  }
 }

--- a/apps/user-service/src/user.model.ts
+++ b/apps/user-service/src/user.model.ts
@@ -110,7 +110,7 @@ export class UserModel extends BaseModel {
   // @ApiProperty({ description: 'OAUTH 授权' })
   // oauth2?: OAuthModel[];
 
-  // @prop({ enum: UserRole, default: UserRole.visitor })
-  // @ApiProperty({ description: '用户角色' })
-  // role?: UserRole;
+  @prop({ enum: UserRole, default: UserRole.visitor })
+  @ApiProperty({ description: '用户角色' })
+  role?: UserRole;
 }

--- a/shared/constants/event.constant.ts
+++ b/shared/constants/event.constant.ts
@@ -1,9 +1,9 @@
 /*
- * @FilePath: /nx-core/shared/constants/event.constant.ts
+ * @FilePath: /mog-core/shared/constants/event.constant.ts
  * @author: Wibus
  * @Date: 2022-09-03 22:18:46
  * @LastEditors: Wibus
- * @LastEditTime: 2022-09-24 15:55:26
+ * @LastEditTime: 2022-10-01 11:10:16
  * Coding With IU
  */
 
@@ -16,6 +16,7 @@ export enum UserEvents {
   UserRegister = 'user.register',
   UserCheck = 'user.check',
   UserGet = 'user.get',
+  UserGetMaster = 'user.get.master',
   UserGetAllSession = 'user.get.session.all',
 }
 


### PR DESCRIPTION
## 此 PR 修改了什么

- 新建一个获取主人信息的接口，与原本的从 username 获取信息分离开
- 新增监听事件 **UserGetMaster** `user.get.master`
- 新建接口 `/user/master/info`

## 此 PR 的额外内容

- 从 username 获取信息的同样可以使用，在未做角色管理前同样可用
- **主人永远只有一个**，但是作者、游客可以有多个