### PR TITLE
perf(nest): use `tsc` to build and make tsconfig file correctly

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,22 @@
+/*
+ * @FilePath: /mog-core/global.d.ts
+ * @author: Wibus
+ * @Date: 2022-10-02 23:42:03
+ * @LastEditors: Wibus
+ * @LastEditTime: 2022-10-02 23:42:03
+ * Coding With IU
+ */
+import { Consola } from 'consola';
+import { ModelType } from '@typegoose/typegoose/lib/types';
+import { Document, PaginateModel } from 'mongoose';
+import 'zx-cjs/globals';
+
+declare global {
+  export const isDev: boolean;
+
+  export const consola: Consola;
+
+  export type MongooseModel<T> = ModelType<T> & PaginateModel<T & Document>;
+}
+
+export {};

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -4,8 +4,8 @@
   "monorepo": true,
   "root": "apps/core",
   "compilerOptions": {
-    "webpack": true,
-    "tsConfigPath": "apps/core/tsconfig.app.json",
+    "webpack": false,
+    "tsConfigPath": "tsconfig.build.json",
     "plugins": [
       {
         "name": "@nestjs/swagger",

--- a/shared/global/index.global.ts
+++ b/shared/global/index.global.ts
@@ -15,17 +15,6 @@ import { consola, registerStdLogger } from './consola.global';
 import './dayjs.global';
 import { isDev } from './env.global';
 import { join } from 'path';
-import { Consola } from 'consola';
-import { ModelType } from '@typegoose/typegoose/lib/types';
-import { Document, PaginateModel } from 'mongoose';
-
-declare global {
-  export const isDev: boolean;
-
-  export const consola: Consola;
-
-  export type MongooseModel<T> = ModelType<T> & PaginateModel<T & Document>;
-}
 
 function consoleMog() {
   console.log(`


### PR DESCRIPTION
## 此 PR 修改了什么？

- 修复了构建时层层报错的问题
- 取消使用 webpack 构建，转而使用 tsc 进行构建

## 报错示例

```bash
[tsl] ERROR in /Users/wibus/Desktop/wibus/Developer/mog-core/shared/common/decorator/api-controller.decorator.ts(3,31)
      TS2304: Cannot find name 'isDev'.

19 errors have detailed information that is not shown.
Use 'stats.errorDetails: true' resp. '--stats-error-details' to show it.

webpack 5.74.0 compiled with 19 errors in 8817 ms
 ELIFECYCLE  Command failed with exit code 1.
```