### PR TITLE
fix(ci): remove db_host

### DIFF
--- a/env.yaml
+++ b/env.yaml
@@ -14,5 +14,5 @@ page_service:
   port: 2332
 
 collection_name: 'mog'
-db_host: 'localhost'
+# db_host: 'localhost'
 jwt_expire: 7d

--- a/scripts/workflow/test-docker.sh
+++ b/scripts/workflow/test-docker.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+###
+ # @Author: ttimochan
+ # @Date: 2023-01-19 13:28:49
+ # @LastEditors: ttimochan
+ # @LastEditTime: 2023-01-19 18:13:15
+ # @FilePath: /mog-core/scripts/workflow/test-docker.sh
+### 
 
 MAX_RETRIES=20
 # Try running the docker and get the output
@@ -18,9 +25,10 @@ if [[ $? -ne 0 ]]; then
   exit 1
 fi
 
-curl https://cdn.jsdelivr.net/gh/mogland/core@main/docker-compose.yml > docker-compose.yml
+curl https://raw.githubusercontent.com/mogland/core/main/docker-compose.yml > docker-compose.yml
 
-curl https://cdn.jsdelivr.net/gh/mogland/core@main/env.yaml > env.yaml
+curl https://raw.githubusercontent.com/mogland/core/main/env.yaml > env.yaml
+
 
 docker-compose up -d
 

--- a/scripts/workflow/test-docker.sh
+++ b/scripts/workflow/test-docker.sh
@@ -27,7 +27,7 @@ fi
 
 curl https://raw.githubusercontent.com/mogland/core/main/docker-compose.yml > docker-compose.yml
 
-curl https://raw.githubusercontent.com/mogland/core/main/env.yaml > env.yaml
+touch env.yaml
 
 
 docker-compose up -d


### PR DESCRIPTION
在 env 文件里面设置默认数据库地址是没有必要的，因为该地址已经有一个默认地址了。
![image](https://user-images.githubusercontent.com/91021824/213415985-282d274e-0741-4a27-b365-33be0b4aa3ae.png)
