### PR TITLE
feat(core): built-in console application

### DIFF
--- a/apps/core/src/app.module.ts
+++ b/apps/core/src/app.module.ts
@@ -22,6 +22,7 @@ import { ClientsModule } from '@nestjs/microservices';
 import { ServicesEnum } from '~/shared/constants/services.constant';
 import { ConfigPublicModule } from './modules/configs/configs.module';
 import { REDIS_TRANSPORTER } from '~/shared/constants/transporter.constants';
+import { ConsoleModule } from './modules/console/console.module';
 
 @Module({
   imports: [
@@ -37,6 +38,7 @@ import { REDIS_TRANSPORTER } from '~/shared/constants/transporter.constants';
     CommentsModule,
     FriendsModule,
     ConfigPublicModule,
+    ConsoleModule,
     ClientsModule.register([
       {
         name: ServicesEnum.notification,

--- a/apps/core/src/bootstrap.ts
+++ b/apps/core/src/bootstrap.ts
@@ -79,7 +79,7 @@ export async function bootstrap() {
     SwaggerModule.setup('api-docs', app, document);
   }
 
-  const listening_ip = getEnv(ServicesEnum.core)['listening_ip'] || '0.0.0.0';
+  const listening_ip = getEnv(ServicesEnum.core)?.['listening_ip'] || '0.0.0.0';
 
   await app.listen(+PORT, listening_ip, async (err) => {
     if (err) {

--- a/apps/core/src/modules/console/console.controller.ts
+++ b/apps/core/src/modules/console/console.controller.ts
@@ -1,6 +1,5 @@
 import { Controller, Get, Inject, Req, Res } from '@nestjs/common';
 import { FastifyRequest, FastifyReply } from 'fastify';
-import { Cookies } from '~/shared/common/decorator/cookie.decorator';
 import { ConsoleService } from './console.service';
 
 @Controller('console')
@@ -11,11 +10,7 @@ export class ConsoleController {
   ) {}
 
   @Get(['/*', '/'])
-  async console(
-    @Cookies() cookies: { [key: string]: string },
-    @Res() res: FastifyReply,
-    @Req() req: FastifyRequest,
-  ) {
+  async console(@Res() res: FastifyReply, @Req() req: FastifyRequest) {
     const path = req.url
       .replace('/console', '')
       .split('/')

--- a/apps/core/src/modules/console/console.controller.ts
+++ b/apps/core/src/modules/console/console.controller.ts
@@ -5,5 +5,6 @@ export class ConsoleController {
   constructor() {}
 
   @Get('/*')
+  @Get()
   console() {}
 }

--- a/apps/core/src/modules/console/console.controller.ts
+++ b/apps/core/src/modules/console/console.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('console')
+export class ConsoleController {
+  constructor() {}
+
+  @Get('/*')
+  console() {}
+}

--- a/apps/core/src/modules/console/console.interface.ts
+++ b/apps/core/src/modules/console/console.interface.ts
@@ -1,0 +1,8 @@
+export interface getPackageIntoInterface {
+  version: string;
+  packages: {
+    name: string;
+    url: string;
+    type: string;
+  }[];
+}

--- a/apps/core/src/modules/console/console.interface.ts
+++ b/apps/core/src/modules/console/console.interface.ts
@@ -1,8 +1,10 @@
 export interface getPackageIntoInterface {
   version: string;
-  packages: {
-    name: string;
-    url: string;
-    type: string;
-  }[];
+  packages: getPackageIntoFiles[];
+}
+
+export interface getPackageIntoFiles {
+  name: string;
+  url: string;
+  type: string;
 }

--- a/apps/core/src/modules/console/console.module.ts
+++ b/apps/core/src/modules/console/console.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
 import { HelperModule } from '~/libs/helper/src';
+import { ConsoleController } from './console.controller';
+import { ConsoleService } from './console.service';
 
 @Module({
   imports: [HelperModule],
-  controllers: [],
-  providers: [],
+  controllers: [ConsoleController],
+  providers: [ConsoleService],
   exports: [],
 })
 export class ConsoleModule {}

--- a/apps/core/src/modules/console/console.module.ts
+++ b/apps/core/src/modules/console/console.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { HelperModule } from '~/libs/helper/src';
+
+@Module({
+  imports: [HelperModule],
+  controllers: [],
+  providers: [],
+  exports: [],
+})
+export class ConsoleModule {}

--- a/apps/core/src/modules/console/console.service.ts
+++ b/apps/core/src/modules/console/console.service.ts
@@ -18,7 +18,7 @@ export class ConsoleService {
   private files: getPackageIntoFiles[] = [];
   constructor(private readonly http: HttpService) {
     this.logger = new Logger(ConsoleService.name);
-    this.env = JSON.parse(process.env.MOG_PRIVATE_ENV!).console as {
+    this.env = JSON.parse(process.env.MOG_PRIVATE_ENV || '{}')?.console as {
       [key: string]: any;
     };
     try {

--- a/apps/core/src/modules/console/console.service.ts
+++ b/apps/core/src/modules/console/console.service.ts
@@ -23,7 +23,7 @@ export class ConsoleService {
     };
     try {
       if (this.env?.enable) {
-        if (this.env?.source === 'gh') {
+        if (this.env?.source !== 'npm') {
           this.getLatestVersionInfoFromGitHub().then((res) => {
             this.files = res.packages;
             consola.success(

--- a/apps/core/src/modules/console/console.service.ts
+++ b/apps/core/src/modules/console/console.service.ts
@@ -68,4 +68,25 @@ export class ConsoleService {
     });
     return returns;
   }
+
+  /**
+   * 把路径转换为文件
+   * @param path 路径
+   */
+  async transformPathToFile(path: string): Promise<string> {
+    const file = this.files.find((file) => file.name === path);
+    if (file) {
+      return await this.http.axiosRef
+        .get(file.url)
+        .then((res) => res.data)
+        .catch(() => {
+          this.logger.error(ExceptionMessage.CONSOLE_INIT_FAILED);
+        });
+    } else {
+      this.logger.error(ExceptionMessage.CONSOLE_INIT_FAILED);
+      throw new InternalServerErrorException(
+        ExceptionMessage.CONSOLE_INIT_FAILED,
+      );
+    }
+  }
 }

--- a/apps/core/src/modules/console/console.service.ts
+++ b/apps/core/src/modules/console/console.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+import { HttpService } from '~/libs/helper/src/helper.http.service';
+
+@Injectable()
+export class ConsoleService {
+  constructor(private readonly http: HttpService) {}
+
+  /**
+   * 从 GitHub Release 获取最新版本信息
+   * @returns 版本号
+   */
+  async getLatestVersionInfoFromGitHub() {
+    const env = process.env.MOG_PRIVATE_ENV as unknown as object as {
+      [key: string]: any;
+    };
+    const type = env.console?.versionType;
+    const url = `https://api.github.com/repos/mogland/console/releases/${
+      type !== 'pre-relese' ? '' : 'latest'
+    }`;
+    const res = JSON.parse(await this.http.axiosRef.get(url));
+    if (type !== 'pre-relese') {
+      return {
+        version: res.tag_name,
+        packages: res.assets.map((asset: any) => {
+          const url = asset.browser_download_url;
+          const name = url.split('/').pop();
+          return {
+            name,
+            url: `https://ghproxy.com/${url}`,
+          };
+        }),
+      };
+    } else {
+      return {
+        version: res[0].tag_name,
+      };
+    }
+  }
+}

--- a/env.yaml
+++ b/env.yaml
@@ -17,6 +17,8 @@ collection_name: 'mog'
 # db_host: 'localhost'
 jwt_expire: 7d
 console:
-  enable: false
+  enable: true
   versionType: "pre-release"
-  source: "gh" # gh or npm, default: npm
+  source: "npm" # gh or npm, default: npm
+  proxy: 
+    gh: "https://getgit.my-api.cn" # default: https://ghproxy.com

--- a/env.yaml
+++ b/env.yaml
@@ -19,6 +19,6 @@ jwt_expire: 7d
 console:
   enable: true
   versionType: "pre-release"
-  source: "npm" # gh or npm, default: npm
+  source: "gh" # gh or npm, default: npm
   proxy: 
     gh: "https://getgit.my-api.cn" # default: https://ghproxy.com

--- a/env.yaml
+++ b/env.yaml
@@ -18,3 +18,4 @@ collection_name: 'mog'
 jwt_expire: 7d
 console:
   versionType: "pre-release"
+  source: "gh" # gh or npm

--- a/env.yaml
+++ b/env.yaml
@@ -17,5 +17,6 @@ collection_name: 'mog'
 # db_host: 'localhost'
 jwt_expire: 7d
 console:
+  enable: false
   versionType: "pre-release"
-  source: "gh" # gh or npm
+  source: "gh" # gh or npm, default: npm

--- a/env.yaml
+++ b/env.yaml
@@ -1,20 +1,4 @@
-core:
-  port: 8080
-  allow_origins: [
-    'localhost:9528',
-    'localhost:2323',
-    'localhost:2222',
-  ]
-  listening_ip: '0.0.0.0'
-user_service:
-  host: 127.0.0.1
-  port: 2331
-page_service:
-  host: 127.0.0.1
-  port: 2332
-
 collection_name: 'mog'
-# db_host: 'localhost'
 jwt_expire: 7d
 console:
   enable: true

--- a/env.yaml
+++ b/env.yaml
@@ -16,3 +16,5 @@ page_service:
 collection_name: 'mog'
 # db_host: 'localhost'
 jwt_expire: 7d
+console:
+  versionType: "pre-release"

--- a/env.yaml
+++ b/env.yaml
@@ -19,6 +19,6 @@ jwt_expire: 7d
 console:
   enable: true
   versionType: "pre-release"
-  source: "gh" # gh or npm, default: npm
+  source: "gh" # gh or npm, default: gh
   proxy: 
     gh: "https://getgit.my-api.cn" # default: https://ghproxy.com

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "consola": "2.15.3",
     "cron": "2.2.0",
     "dayjs": "1.11.7",
+    "fastify": "^4.12.0",
     "js-yaml": "^4.1.0",
     "jsdom": "^21.0.0",
     "jsonwebtoken": "9.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,7 @@ specifiers:
   eslint: 8.32.0
   eslint-config-prettier: 8.6.0
   eslint-plugin-prettier: 4.2.1
+  fastify: ^4.12.0
   husky: 8.0.3
   inquirer: 9.1.4
   ioredis: 5.2.5
@@ -111,6 +112,7 @@ dependencies:
   consola: 2.15.3
   cron: 2.2.0
   dayjs: 1.11.7
+  fastify: 4.12.0
   js-yaml: 4.1.0
   jsdom: 21.0.0
   jsonwebtoken: 9.0.0
@@ -3768,6 +3770,10 @@ packages:
       tmp: 0.0.33
     dev: true
 
+  /fast-content-type-parse/1.0.0:
+    resolution: {integrity: sha512-Xbc4XcysUXcsP5aHUU7Nq3OwvHq97C+WnbkeIefpeYLX+ryzFJlU6OStFJhs6Ol0LkUGpcK+wL0JwfM+FCU5IA==}
+    dev: false
+
   /fast-decode-uri-component/1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
     dev: false
@@ -3849,6 +3855,28 @@ packages:
       abstract-logging: 2.0.1
       avvio: 8.2.0
       content-type: 1.0.4
+      find-my-way: 7.3.1
+      light-my-request: 5.6.1
+      pino: 8.6.1
+      process-warning: 2.0.0
+      proxy-addr: 2.0.7
+      rfdc: 1.3.0
+      secure-json-parse: 2.5.0
+      semver: 7.3.8
+      tiny-lru: 10.0.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /fastify/4.12.0:
+    resolution: {integrity: sha512-Hh2GCsOCqnOuewWSvqXlpq5V/9VA+/JkVoooQWUhrU6gryO9+/UGOoF/dprGcKSDxkM/9TkMXSffYp8eA/YhYQ==}
+    dependencies:
+      '@fastify/ajv-compiler': 3.3.1
+      '@fastify/error': 3.0.0
+      '@fastify/fast-json-stringify-compiler': 4.1.0
+      abstract-logging: 2.0.1
+      avvio: 8.2.0
+      fast-content-type-parse: 1.0.0
       find-my-way: 7.3.1
       light-my-request: 5.6.1
       pino: 8.6.1

--- a/shared/common/decorator/cookie.decorator.ts
+++ b/shared/common/decorator/cookie.decorator.ts
@@ -13,7 +13,6 @@ export const Cookies = createParamDecorator(
     const request = ctx.switchToHttp().getRequest();
     // 获取 header 中的 cookie
     const cookies = request.headers.cookie;
-    console.log(cookies);
     // 解析 cookie
     const cookie = cookies ? cookies.split('; ') : [];
     const cookieObj = {};

--- a/shared/constants/echo.constant.ts
+++ b/shared/constants/echo.constant.ts
@@ -37,4 +37,9 @@ export enum ExceptionMessage {
   FriendLinkIsNotExist = '友链不存在 o(╯□╰)o',
   FriendLinkTokenIsInvalid = '友链Token无效，可能找错了哦',
   FriendLinkIsExist = '友链已存在 o(╯□╰)o',
+
+  ConsoleFileIsNotExist = '@mogland/console 所期望请求的文件不存在，请提交 issues 至 mogland/console',
+  CONSOLE_INIT_FAILED = '@mogland/console 文件初始化失败，请提交 issues 至 mogland/console',
+  ConsoleInitSuccess = '控制台服务初始化成功',
+  ConsoleIsDisabled = '控制台服务已被禁用',
 }

--- a/shared/constants/echo.constant.ts
+++ b/shared/constants/echo.constant.ts
@@ -42,4 +42,5 @@ export enum ExceptionMessage {
   CONSOLE_INIT_FAILED = '@mogland/console 文件初始化失败，请提交 issues 至 mogland/console',
   ConsoleInitSuccess = '控制台服务初始化成功',
   ConsoleIsDisabled = '控制台服务已被禁用',
+  CONSOLE_REQUEST_FAILED = '控制台资源请求失败！',
 }

--- a/shared/types/npm.ts
+++ b/shared/types/npm.ts
@@ -1,0 +1,21 @@
+export interface NPMFiles {
+  files: FilesClass;
+  totalSize: number;
+  fileCount: number;
+  shasum: string;
+  integrity: string;
+}
+
+export interface FilesClass {
+  [filename: string]: License;
+}
+
+export interface License {
+  size: number;
+  type: string;
+  path: string;
+  contentType: string;
+  hex: string;
+  isBinary: string;
+  linesCount: number;
+}


### PR DESCRIPTION
<img width="1001" alt="image" src="https://user-images.githubusercontent.com/62133302/213914149-94607908-d33d-4cce-86fa-a8fecf4b377d.png">

## Tasks

- [x] 文档相关部分更新 ( `/config/` )

## 核心逻辑

将全部请求转接到后端中，把 Cookie 等注入返回中，请求远端 HTML 等文件，将内容返回

### 新增自定义配置

```yaml
console:
  enable: false
  versionType: "pre-release"
  source: "gh" # gh or npm, default: npm
  proxy: 
    gh: "https://ghproxy.com" # default: https://ghproxy.com
```

- **enable**: 服务启动
- **versionType**: 版本类型，若需要使用非正式版本，则填入 `pre-release`，若需要正式版本，则无所谓
- **source**: 获取方式，gh 即 GitHub Release，npm 即 npmjs.com。事实上，并不建议使用 npm 方式，这似乎会导致 rate limit
- **proxy**: 下载“代理”，是指使用 ghproxy 类型的工具下载包
  - **gh**：GitHub Release 的下载代理，默认为 `https://ghproxy.com`
  - **npm**: _**没有提供支持**_ -- 原因是我们从 npm 获取文件使用的是官方的一个接口 `https://www.npmjs.com/package/${name}/file/${fileId}`，而此接口似乎无镜像