### PR TITLE
fix: catch reading nonexistent env file error

### DIFF
--- a/shared/utils/rag-env.ts
+++ b/shared/utils/rag-env.ts
@@ -39,8 +39,13 @@ export const readEnv: (
   config = merge(config, argv);
 
   const envPath = path || join(cwd, 'env.yaml');
-  const env = readFileSync(envPath, 'utf-8');
-  if (!env) return config;
+  let env: string;
+  try {
+    readFileSync(envPath, 'utf-8');
+  } catch (error) {
+    return config;
+  }
+  if (!env!) return config;
   const envObj = yaml.load(env);
   // 与 config 合并
   config = merge(config, envObj);


### PR DESCRIPTION
## What's Changed

- **fix**: 捕获读取不存在的 env 文件的错误