### PR TITLE
feat(microservice): transport custom events

### DIFF
--- a/apps/core/src/app.controller.ts
+++ b/apps/core/src/app.controller.ts
@@ -1,4 +1,15 @@
-import { Controller, Get, Inject } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Inject,
+  Param,
+  Patch,
+  Post,
+  Put,
+  Query,
+} from '@nestjs/common';
 import { AppService } from './app.service';
 import PKG from '../../../package.json';
 import { ApiOperation } from '@nestjs/swagger';
@@ -42,5 +53,47 @@ export class AppController {
       NotificationEvents.Ping,
       {},
     );
+  }
+
+  @Get('/*')
+  @ApiOperation({ summary: '自定义 Path (GET)' })
+  async customGetPath(@Query() query: any, @Param() param: any) {
+    return this.appService.transformCustomPath('GET', query, param);
+  }
+
+  @Post('/*')
+  @ApiOperation({ summary: '自定义 Path (POST)' })
+  async customPostPath(
+    @Query() query: any,
+    @Param() param: any,
+    @Body() body: any,
+  ) {
+    return this.appService.transformCustomPath('POST', query, param, body);
+  }
+
+  @Put('/*')
+  @ApiOperation({ summary: '自定义 Path (PUT)' })
+  async customPutPath(
+    @Query() query: any,
+    @Param() param: any,
+    @Body() body: any,
+  ) {
+    return this.appService.transformCustomPath('PUT', query, param, body);
+  }
+
+  @Patch('/*')
+  @ApiOperation({ summary: '自定义 Path (PATCH)' })
+  async customPatchPath(
+    @Query() query: any,
+    @Param() param: any,
+    @Body() body: any,
+  ) {
+    return this.appService.transformCustomPath('PATCH', query, param, body);
+  }
+
+  @Delete('/*')
+  @ApiOperation({ summary: '自定义 Path (DELETE)' })
+  async customDeletePath(@Query() query: any, @Param() param: any) {
+    return this.appService.transformCustomPath('DELETE', query, param);
   }
 }

--- a/apps/core/src/app.module.ts
+++ b/apps/core/src/app.module.ts
@@ -46,6 +46,10 @@ import { ThemesModule } from './modules/themes/themes.module';
         name: ServicesEnum.notification,
         ...REDIS_TRANSPORTER,
       },
+      {
+        name: ServicesEnum.custom,
+        ...REDIS_TRANSPORTER,
+      }
     ]),
   ],
   controllers: [AppController],

--- a/apps/core/src/app.service.ts
+++ b/apps/core/src/app.service.ts
@@ -11,6 +11,7 @@ interface IEventConfigItem {
   path: string;
   method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
   handler: string;
+  emit?: boolean;
 }
 
 interface IEventConfig {
@@ -101,7 +102,8 @@ export class AppService {
     const pathParam = config.path // /user/{id}/info
       .split('/')
       .filter((item: string) => item.startsWith('{') && item.endsWith('}'));
-    const param = pathParam.reduce((acc, cur, index) => { // { id: '1' }
+    const param = pathParam.reduce((acc, cur, index) => {
+      // { id: '1' }
       acc[cur.replace(/{|}/g, '')] = _path[index + 2];
       return acc;
     }, {});
@@ -123,6 +125,12 @@ export class AppService {
     if (!config) throw new NotFoundException();
     const handler = config.handler;
     const data = this.transportData(config, query, param, body);
-    return transportReqToMicroservice(this.custom, handler, data);
+    return transportReqToMicroservice(
+      this.custom,
+      handler,
+      data,
+      3000,
+      config.emit,
+    );
   }
 }

--- a/apps/core/src/app.service.ts
+++ b/apps/core/src/app.service.ts
@@ -1,8 +1,128 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { ClientProxy } from '@nestjs/microservices';
+import { join } from 'path';
+import { cwd } from '@shared/global/env.global';
+import { ServicesEnum } from '~/shared/constants/services.constant';
+import { readFileSync } from 'fs';
+import { YAML } from 'zx-cjs';
+import { transportReqToMicroservice } from '~/shared/microservice.transporter';
+
+interface IEventConfigItem {
+  path: string;
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  handler: string;
+}
+
+interface IEventConfig {
+  [key: string]: IEventConfigItem[];
+}
 
 @Injectable()
 export class AppService {
-  getHello(): string {
-    return 'Hello World!';
+  private eventConfig: IEventConfig;
+
+  constructor(
+    @Inject(ServicesEnum.custom)
+    private readonly custom: ClientProxy,
+  ) {
+    this.getEventConfigFile();
+    this.watchConfigFile();
+  }
+
+  private getEventConfigFile() {
+    const envPath = join(cwd, 'events.yaml');
+    let env: string;
+    try {
+      env = readFileSync(envPath, 'utf-8');
+    } catch (error) {
+      return '';
+    }
+    const envObj = YAML.parse(env);
+    Object.keys(envObj).forEach((key) => {
+      envObj[key] = envObj[key].map(
+        (item: { method: string; path: string }) => ({
+          ...item,
+          method: item.method.toUpperCase(),
+          path: item.path.replace(/^\//, ''),
+        }),
+      );
+    });
+    this.eventConfig = envObj;
+  }
+
+  private watchConfigFile() {
+    try {
+      fs.watch(join(cwd, 'events.yaml'), (_eventType: any, filename: any) => {
+        if (filename) {
+          this.getEventConfigFile();
+        }
+      });
+    } catch {
+      /* empty */
+    }
+  }
+
+  private getClient(param: string) {
+    const name = param['*'].split('/')[0];
+    const client = this.eventConfig[name];
+    if (!client) return null;
+    return client;
+  }
+
+  private validatePathWithMethod(
+    method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
+    param: any,
+  ) {
+    const client = this.getClient(param);
+    if (!client) return null;
+    const path = param['*'].split('/').slice(1).join('/');
+    const length = path.split('/').length;
+    const config =
+      client.find((item) => item.path === path) ||
+      client.find(
+        (item) =>
+          item.path.split('/').length === length &&
+          item.path
+            .split('/')
+            .map((item) => item.startsWith('{') && item.endsWith('}')),
+      );
+    if (!config) return null;
+    if (config.method !== method) return null;
+    return config;
+  }
+
+  private transportData(
+    config: IEventConfigItem,
+    query: any,
+    _param: any,
+    body?: any,
+  ) {
+    const _path = _param['*'].split('/');
+    const pathParam = config.path // /user/{id}/info
+      .split('/')
+      .filter((item: string) => item.startsWith('{') && item.endsWith('}'));
+    const param = pathParam.reduce((acc, cur, index) => { // { id: '1' }
+      acc[cur.replace(/{|}/g, '')] = _path[index + 2];
+      return acc;
+    }, {});
+    return {
+      query,
+      param: _param,
+      body,
+      ...param,
+    };
+  }
+
+  async transformCustomPath(
+    method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
+    query: any,
+    param: any,
+    body?: any,
+  ) {
+    const config = this.validatePathWithMethod(method, param);
+    if (!config) throw new NotFoundException();
+    const handler = config.handler;
+    const data = this.transportData(config, query, param, body);
+    return transportReqToMicroservice(this.custom, handler, data);
   }
 }

--- a/env.yaml
+++ b/env.yaml
@@ -1,8 +1,0 @@
-collection_name: 'mog'
-jwt_expire: 7d
-console:
-  enable: true
-  versionType: 'pre-release'
-  source: 'gh' # gh or npm, default: gh
-  proxy:
-    gh: 'https://getgit.my-api.cn' # default: https://ghproxy.com

--- a/events.yaml
+++ b/events.yaml
@@ -1,0 +1,10 @@
+render:
+  - path: /events
+    method: get
+    handler: events.get
+  - path: /events/{id}
+    method: get
+    handler: events.get.id
+  - path: /events
+    method: post
+    handler: events.post

--- a/shared/constants/services.constant.ts
+++ b/shared/constants/services.constant.ts
@@ -22,6 +22,7 @@ export enum ServicesEnum {
   admin = 'ADMIN_SERVICE',
   mail = 'MAIL_SERVICE',
   notification = 'NOTIFICATION_SERVICE',
+  custom = 'CUSTOM_SERVICE',
 }
 
 export enum ServicePorts {

--- a/shared/microservice.transporter.ts
+++ b/shared/microservice.transporter.ts
@@ -7,7 +7,11 @@ export function transportReqToMicroservice<T = any>(
   cmd: string,
   data: any,
   time = 3000,
+  emit = false,
 ): Promise<T> {
+  if (emit) {
+    return lastValueFrom(client.emit<T>(cmd, data));
+  }
   const send = client.send<T>({ cmd }, data).pipe(
     timeout(time),
     catchError((err) => {

--- a/shared/utils/rag-env.ts
+++ b/shared/utils/rag-env.ts
@@ -8,7 +8,7 @@
  */
 
 import { join } from 'path';
-import { cwd } from 'shared/global/env.global';
+import { cwd } from '@shared/global/env.global';
 import { argv as zxArev, YAML } from 'zx-cjs';
 import { camelToUnderline } from './name';
 import { ServicesEnum } from '../constants/services.constant';


### PR DESCRIPTION
需要新增一个 `events.yaml`

接口如下：

```ts
interface IEventConfigItem {
  path: string;
  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
  handler: string;
  emit?: boolean;
}

interface IEventConfig {
  [key: string]: IEventConfigItem[];
}
```

示例：

```yaml
render: # controller --> {API}/render/*
  - path: /events # {API}/render/events
    method: get
    handler: events.get # 发布活动
  - path: /events/{id} # {API}/render/events/{id}
    method: get
    handler: events.get.id
  - path: /events
    method: post
    handler: events.post
```

<img width="809" alt="image" src="https://user-images.githubusercontent.com/62133302/218303740-ba200f3e-df69-42a3-a0a4-e980e9b7d8fe.png">
